### PR TITLE
Fix errors on nftmarket.js for old nft own buys

### DIFF
--- a/contracts/nftmarket.js
+++ b/contracts/nftmarket.js
@@ -64,7 +64,7 @@ async function parseNftChangePrice(collection, nftCollection, sender, contract, 
 }
 
 async function parseNftBuy(collection, nftCollection, sender, contract, action, tx, events, payloadObj) {
-  if (events && events.length > 0) {
+  if (events && events.length > 1) {
     const insertTx = {
       ...tx,
     };


### PR DESCRIPTION
Buying an NFT involves two events, and the parseNftBuy expects that. This is a fix to that.

However this resulted in a problem happening when someone in the past (not the case anymore) would buy an NFT of its own listing. 

In this case, the events would be only 1, and the part of the function that needs the second item of the array would fail.

This is to resolve the issue: https://github.com/hive-engine/ssc_tokens_history/issues/26

Requirements: None

Conclusion: The problematic events of the specific blocks will not be throwing an error anymore with this. But they will still not be parsed.